### PR TITLE
Setting supported .NET Framework version

### DIFF
--- a/samples/Services/VS2015/WebApplication/WebService/App.config
+++ b/samples/Services/VS2015/WebApplication/WebService/App.config
@@ -2,6 +2,6 @@
 
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   </startup>
 </configuration>


### PR DESCRIPTION
Azure IaaS VMs only have .NET 4.5.1 so far.