### PR TITLE
VisualObjects sample missing Actors reference in Website project

### DIFF
--- a/samples/Actors/VS2015/VisualObjects/VisualObjects.WebService/VisualObjects.WebService.csproj
+++ b/samples/Actors/VS2015/VisualObjects/VisualObjects.WebService/VisualObjects.WebService.csproj
@@ -53,6 +53,10 @@
       <HintPath>$(SolutionDir)packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.ServiceFabric.Actors, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Microsoft.ServiceFabric.Actors.1.0.328-preview1\lib\net45\Microsoft.ServiceFabric.Actors.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/samples/Actors/VS2015/VisualObjects/VisualObjects.WebService/packages.config
+++ b/samples/Actors/VS2015/VisualObjects/VisualObjects.WebService/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net45" userInstalled="true" />
+  <package id="Microsoft.ServiceFabric.Actors" version="1.0.328-preview1" targetFramework="net45" userInstalled="true"  />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
   <package id="Owin" version="1.0" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.ServiceFabric.Services" version="1.0.328-preview1" targetFramework="net45" />


### PR DESCRIPTION
The WebService project on the Actor VisualObjects sample was missing the Microsoft.ServiceFabric.Actors reference. I've added it as a reference and ensured it's in the packages config.